### PR TITLE
Fix warnings & add bibliography to TOC

### DIFF
--- a/engineer.tex
+++ b/engineer.tex
@@ -150,7 +150,7 @@ Tabela dotycząca wymagań pozafunkcjonalnych \ref{tab:requirements:nonfunc1} je
 \end{requirementstab}
 
 
-\printbibliography[title={Bibliografia}]
+\printbibliography[title={Bibliografia}, heading=bibintoc]
 
 
 

--- a/engineer.tex
+++ b/engineer.tex
@@ -1,4 +1,5 @@
 \documentclass{sprz}
+\usepackage[backend=biber,style=numeric,sorting=none]{biblatex}
 
 \addbibresource{bibliography.bib}
 
@@ -86,67 +87,67 @@ albo dla wygody jako makro tak jak na obrazku~\ref{img:pjatklogo2}
 Na tabeli \ref{tab:requirements:general} pokazano jak można definiować wymagania ogólne lub dziedzinowe.
 
 \begin{requirementstab}[label={tab:requirements:general},caption={Przykładowe wymaganie ogólne lub dziedzinowe}]
-    \id{jednoznaczny symbol np. WO1, WO2 .. } 
+    \id{jednoznaczny symbol np. WO1, WO2 .. }
     \priority{ważność wymagania, np. wg skali MoSCoW: M – must (musi być) S – should (powinno być) C – could (może być) W – won't (nie będzie – nie będzie implementowane w danym wydaniu, ale może być rozpatrzone w przyszłości )}
-    \name{krótki opis} 
-    \descr{opis szczegółowy, należy dążyć do tego, żeby wszystkie znane na ten moment szczegóły wymagania zostały wydobyte i wyspecyfikowane} 
-    \sholder{nazwa udziałowca, który podał wymaganie} 
-    \reqrelated{wymagania zależne i uszczegóławiające – odesłanie poprzez identyfikator} 
+    \name{krótki opis}
+    \descr{opis szczegółowy, należy dążyć do tego, żeby wszystkie znane na ten moment szczegóły wymagania zostały wydobyte i wyspecyfikowane}
+    \sholder{nazwa udziałowca, który podał wymaganie}
+    \reqrelated{wymagania zależne i uszczegóławiające – odesłanie poprzez identyfikator}
 \end{requirementstab}
 
 Teraz czas na wymagania funkcjonalne, na przykład \ref{tab:requirements:func1}
 
 \begin{requirementstab}[label={tab:requirements:func1},caption={Pryzkładowa tabela z wymaganiami na interfejs z otoczeniem}]
-    \id{jednoznaczny symbol np. FO1, FO2 .. } 
+    \id{jednoznaczny symbol np. FO1, FO2 .. }
     \priority{ważność wymagania, np. wg skali MoSCoW: M – must (musi być) S – should (powinno być) C – could (może być) W – won't (nie będzie – nie będzie implementowane w danym wydaniu, ale może być rozpatrzone w przyszłości )}
-    \name{krótki opis} 
+    \name{krótki opis}
     \descr{opis szczegółowy, należy dążyć do tego, żeby wszystkie znane na ten moment szczegóły wymagania zostały wydobyte i wyspecyfikowane
 
-    Można zastosować opis jak w User Story 
+    Można zastosować opis jak w User Story
     \begin{itemize}
-        \item Jako.. (konkretny użytkownik systemu) 
-        \item chcę... (pożądana cecha lub problem, który trzeba rozwiązać) 
+        \item Jako.. (konkretny użytkownik systemu)
+        \item chcę... (pożądana cecha lub problem, który trzeba rozwiązać)
         \item bo wtedy/ponieważ… (korzyść płynąca z ukończenia story)
     \end{itemize}
-    } 
+    }
     \acceptcrit{Warunki Satysfakcji (Szczegóły dodane na potrzeby  testów akceptacyjnych)}
-    \inputdata{uzupełniane w trakcie sprintu – dane wejściowe, związane z wymaganiem} 
-    \preconditions{ uzupełniane w trakcie sprintu – warunki, które muszą być prawdziwe przed wywołaniem operacji} 
-    \postconditions{ uzupełniane w trakcie sprintu – warunki, które muszą być prawdziwe po wywołaniu operacji} 
-    \exceptions{ uzupełniane w trakcie sprintu – niepożądane sytuacje i sposoby ich obsługi} 
-    \implementation{ uzupełniane w trakcie sprintu – opis sposobu realizacji} 
-    \sholder{nazwa udziałowca, który podał wymaganie} 
-    \reqrelated{wymagania zależne i uszczegóławiające – odesłanie poprzez identyfikator} 
+    \inputdata{uzupełniane w trakcie sprintu – dane wejściowe, związane z wymaganiem}
+    \preconditions{ uzupełniane w trakcie sprintu – warunki, które muszą być prawdziwe przed wywołaniem operacji}
+    \postconditions{ uzupełniane w trakcie sprintu – warunki, które muszą być prawdziwe po wywołaniu operacji}
+    \exceptions{ uzupełniane w trakcie sprintu – niepożądane sytuacje i sposoby ich obsługi}
+    \implementation{ uzupełniane w trakcie sprintu – opis sposobu realizacji}
+    \sholder{nazwa udziałowca, który podał wymaganie}
+    \reqrelated{wymagania zależne i uszczegóławiające – odesłanie poprzez identyfikator}
 \end{requirementstab}
 
 
 Natomiast tabela \ref{tab:requirements:env1} pokazuje wymagania na interfejs z otoczeniem.
 
 \begin{requirementstab}[label={tab:requirements:env1},caption={Pryzkładowa tabela z wymaganiami na interfejs z otoczeniem}]
-    \id{jednoznaczny symbol np. IO1, IO2 .. } 
+    \id{jednoznaczny symbol np. IO1, IO2 .. }
     \priority{ważność wymagania, np. wg skali MoSCoW: M – must (musi być) S – should (powinno być) C – could (może być) W – won't (nie będzie – nie będzie implementowane w danym wydaniu, ale może być rozpatrzone w przyszłości )}
-    \name{krótki opis} 
-    \descr{opis szczegółowy, należy dążyć do tego, żeby wszystkie znane na ten moment szczegóły wymagania zostały wydobyte i wyspecyfikowane} 
+    \name{krótki opis}
+    \descr{opis szczegółowy, należy dążyć do tego, żeby wszystkie znane na ten moment szczegóły wymagania zostały wydobyte i wyspecyfikowane}
     \acceptcrit{Warunki Satysfakcji (Szczegóły dodane na potrzeby  testów akceptacyjnych)}
-    \inputdata{uzupełniane w trakcie sprintu – dane wejściowe, związane z wymaganiem} 
-    \preconditions{ uzupełniane w trakcie sprintu – warunki, które muszą być prawdziwe przed wywołaniem operacji} 
-    \postconditions{ uzupełniane w trakcie sprintu – warunki, które muszą być prawdziwe po wywołaniu operacji} 
-    \exceptions{ uzupełniane w trakcie sprintu – niepożądane sytuacje i sposoby ich obsługi} 
-    \implementation{ uzupełniane w trakcie sprintu – opis sposobu realizacji} 
-    \sholder{nazwa udziałowca, który podał wymaganie} 
-    \reqrelated{wymagania zależne i uszczegóławiające – odesłanie poprzez identyfikator} 
+    \inputdata{uzupełniane w trakcie sprintu – dane wejściowe, związane z wymaganiem}
+    \preconditions{ uzupełniane w trakcie sprintu – warunki, które muszą być prawdziwe przed wywołaniem operacji}
+    \postconditions{ uzupełniane w trakcie sprintu – warunki, które muszą być prawdziwe po wywołaniu operacji}
+    \exceptions{ uzupełniane w trakcie sprintu – niepożądane sytuacje i sposoby ich obsługi}
+    \implementation{ uzupełniane w trakcie sprintu – opis sposobu realizacji}
+    \sholder{nazwa udziałowca, który podał wymaganie}
+    \reqrelated{wymagania zależne i uszczegóławiające – odesłanie poprzez identyfikator}
 \end{requirementstab}
 
 Tabela dotycząca wymagań pozafunkcjonalnych \ref{tab:requirements:nonfunc1} jest także widoczne.
 
 \begin{requirementstab}[label={tab:requirements:nonfunc1},caption={Pryzkładowa tabela z wymaganiami pozafunkcjonalnymi}]
-    \id{jednoznaczny symbol np. NFO1, NFO2 .. } 
+    \id{jednoznaczny symbol np. NFO1, NFO2 .. }
     \priority{ważność wymagania, np. wg skali MoSCoW: M – must (musi być) S – should (powinno być) C – could (może być) W – won't (nie będzie – nie będzie implementowane w danym wydaniu, ale może być rozpatrzone w przyszłości )}
-    \name{krótki opis} 
-    \descr{opis szczegółowy, należy dążyć do tego, żeby wszystkie znane na ten moment szczegóły wymagania zostały wydobyte i wyspecyfikowane} 
+    \name{krótki opis}
+    \descr{opis szczegółowy, należy dążyć do tego, żeby wszystkie znane na ten moment szczegóły wymagania zostały wydobyte i wyspecyfikowane}
     \acceptcrit{Warunki Satysfakcji (Szczegóły dodane na potrzeby  testów akceptacyjnych)}
-    \sholder{nazwa udziałowca, który podał wymaganie} 
-    \reqrelated{wymagania zależne i uszczegóławiające – odesłanie poprzez identyfikator} 
+    \sholder{nazwa udziałowca, który podał wymaganie}
+    \reqrelated{wymagania zależne i uszczegóławiające – odesłanie poprzez identyfikator}
 \end{requirementstab}
 
 

--- a/sprz.cls
+++ b/sprz.cls
@@ -15,13 +15,13 @@
 \RequirePackage[utf8]{inputenc}
 \RequirePackage{polski} % Włączenie obsługi polskich liter
 \RequirePackage{tabularx}
-\RequirePackage[backend=bibtex,style=numeric,sorting=none]{biblatex}
+\RequirePackage[backend=biber,style=numeric,sorting=none]{biblatex}
 \RequirePackage{url}
 \RequirePackage{graphicx}
 \RequirePackage[pscoord]{eso-pic}% The zero point of the coordinate systemis the lower left corner of the page (the default).
 \RequirePackage{multirow}
 \RequirePackage{graphicx}
-
+\RequirePackage{csquotes}
 
 \newcommand{\@nabstract}{\@latex@error{No \noexpand\@nabstract given}\@ehc}
 \newcommand{\nabstract}[1]{\renewcommand{\@nabstract}{#1}}

--- a/sprz.cls
+++ b/sprz.cls
@@ -15,13 +15,11 @@
 \RequirePackage[utf8]{inputenc}
 \RequirePackage{polski} % Włączenie obsługi polskich liter
 \RequirePackage{tabularx}
-\RequirePackage[backend=biber,style=numeric,sorting=none]{biblatex}
 \RequirePackage{url}
 \RequirePackage{graphicx}
 \RequirePackage[pscoord]{eso-pic}% The zero point of the coordinate systemis the lower left corner of the page (the default).
 \RequirePackage{multirow}
 \RequirePackage{graphicx}
-\RequirePackage{csquotes}
 
 \newcommand{\@nabstract}{\@latex@error{No \noexpand\@nabstract given}\@ehc}
 \newcommand{\nabstract}[1]{\renewcommand{\@nabstract}{#1}}


### PR DESCRIPTION
Fixed:
```
Package biblatex Warning: Using fall-back BibTeX(8) backend:
(biblatex)                functionality may be reduced/unavailable.
```
and:
```
Package biblatex Warning: 'babel/polyglossia' detected but 'csquotes' missing.
(biblatex)                Loading 'csquotes' recommended.
```

To include bibliographty in toc use `\printbibliography[heading=bibintoc]`